### PR TITLE
Implements osm::Lane and osm::Segment classes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(maliput_osm)

--- a/src/maliput_osm/CMakeLists.txt
+++ b/src/maliput_osm/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(osm)

--- a/src/maliput_osm/osm/lane.h
+++ b/src/maliput_osm/osm/lane.h
@@ -31,17 +31,17 @@
 
 #include <optional>
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 #include <maliput_sparse/geometry/line_string.h>
 
 namespace maliput_osm {
 namespace osm {
 
-using LaneId = std::string;
-
 /// A lane in an Lanelet2-OSM road.
 struct Lane {
+  using Id = std::string;
+
   /// Equality operator.
   /// @param other The other object to compare against.
   bool operator==(const Lane& other) const {
@@ -50,19 +50,19 @@ struct Lane {
   }
 
   /// Id of the lane.
-  LaneId id{};
+  Id id{};
   /// The lane's left boundary.
   maliput_sparse::geometry::LineString3d left;
   /// The lane's right boundary.
   maliput_sparse::geometry::LineString3d right;
   /// The id of the lane to the left of this lane.
-  std::optional<LaneId> left_lane_id;
+  std::optional<Id> left_lane_id;
   /// The id of the lane to the right of this lane.
-  std::optional<LaneId> right_lane_id;
+  std::optional<Id> right_lane_id;
   /// The ids of the lanes that follow this lane.
-  std::vector<LaneId> successors;
+  std::unordered_set<Id> successors;
   /// The ids of the lanes that precede this lane.
-  std::vector<LaneId> predecessors;
+  std::unordered_set<Id> predecessors;
 };
 
 }  // namespace osm

--- a/src/maliput_osm/osm/lane.h
+++ b/src/maliput_osm/osm/lane.h
@@ -1,0 +1,125 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <maliput/api/type_specific_identifier.h>
+#include <maliput/common/maliput_copyable.h>
+#include <maliput_sparse/geometry/line_string.h>
+
+namespace maliput_osm {
+namespace osm {
+
+using LaneId = maliput::api::TypeSpecificIdentifier<class Lane>;
+
+/// A lane in an Lanelet2-OSM road.
+class Lane {
+ public:
+  /// Constructs a Lane
+  /// @param id Id of the lane.
+  /// @param left Left polyline describing the left boundary of the lane.
+  /// @param right Right polyline describing the right boundary of the lane.
+  Lane(const LaneId& id, const maliput_sparse::geometry::LineString3d& left,
+       const maliput_sparse::geometry::LineString3d& right)
+      : id_(id), left_(left), right_(right) {}
+
+  /// Constructs a Lane
+  /// @param id Id of the lane.
+  /// @param left Left polyline describing the left boundary of the lane.
+  /// @param right Right polyline describing the right boundary of the lane.
+  /// @param left_lane_id Id of the lane to the left of this lane.
+  /// @param right_lane_id Id of the right to the left of this lane.
+  /// @param successors Ids of the lanes that are successors of this lane.
+  /// @param predecessors Ids of the lanes that are predecessors of this lane.
+  Lane(const LaneId& id, const maliput_sparse::geometry::LineString3d& left,
+       const maliput_sparse::geometry::LineString3d& right, const std::optional<LaneId>& left_lane_id,
+       const std::optional<LaneId>& right_lane_id, const std::vector<LaneId>& successors,
+       const std::vector<LaneId>& predecessors)
+      : id_(id),
+        left_(left),
+        right_(right),
+        left_lane_id_(left_lane_id),
+        right_lane_id_(right_lane_id),
+        successors_(successors),
+        predecessors_(predecessors) {}
+
+  /// Returns the id of the lane.
+  const LaneId& id() const { return id_; }
+  /// Returns the left polyline describing the left boundary of the lane.
+  const maliput_sparse::geometry::LineString3d& left() const { return left_; }
+  /// Returns the right polyline describing the right boundary of the lane.
+  const maliput_sparse::geometry::LineString3d& right() const { return right_; }
+
+  /// Set the id of the lane to the left of this lane.
+  /// @param left_lane_id Left LaneId.
+  void set_left_lane_id(const std::optional<LaneId>& left_lane_id) { left_lane_id_ = left_lane_id; }
+  /// Set the id of the lane to the right of this lane.
+  /// @param right_lane_id Right LaneId.
+  void set_right_lane_id(const std::optional<LaneId>& right_lane_id) { right_lane_id_ = right_lane_id; }
+  /// @returns The id of the lane to the left of this lane.
+  const std::optional<LaneId>& get_left_lane_id() const { return left_lane_id_; }
+  /// @returns The id of the lane to the right of this lane.
+  const std::optional<LaneId>& get_right_lane_id() const { return right_lane_id_; }
+
+  /// Set the ids of the lanes that succeed this lane.
+  /// @param successors Successors.
+  void set_successors(const std::vector<LaneId>& successors) { successors_ = successors; }
+  /// Set the ids of the lanes that precede this lane.
+  /// @param predecessors Predecessors.
+  void set_predecessors(const std::vector<LaneId>& predecessors) { predecessors_ = predecessors; }
+  /// @returns The ids of the lanes that succeed this lane.
+  const std::vector<LaneId>& get_successors() const { return successors_; }
+  /// @returns The ids of the lanes that precede this lane.
+  const std::vector<LaneId>& get_predecessors() const { return predecessors_; }
+
+  /// Equality operator.
+  /// @param other Other Lane.
+  bool operator==(const Lane& other) const {
+    return id_ == other.id_ && left_ == other.left_ && right_ == other.right_ && left_lane_id_ == other.left_lane_id_ &&
+           right_lane_id_ == other.right_lane_id_ && successors_ == other.successors_ &&
+           predecessors_ == other.predecessors_;
+  }
+
+ private:
+  const LaneId id_;
+  const maliput_sparse::geometry::LineString3d left_;
+  const maliput_sparse::geometry::LineString3d right_;
+  std::optional<LaneId> left_lane_id_;
+  std::optional<LaneId> right_lane_id_;
+  std::vector<LaneId> successors_;
+  std::vector<LaneId> predecessors_;
+};
+
+}  // namespace osm
+}  // namespace maliput_osm

--- a/src/maliput_osm/osm/lane.h
+++ b/src/maliput_osm/osm/lane.h
@@ -29,96 +29,40 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include <maliput/api/type_specific_identifier.h>
-#include <maliput/common/maliput_copyable.h>
 #include <maliput_sparse/geometry/line_string.h>
 
 namespace maliput_osm {
 namespace osm {
 
-using LaneId = maliput::api::TypeSpecificIdentifier<class Lane>;
+using LaneId = std::string;
 
 /// A lane in an Lanelet2-OSM road.
-class Lane {
- public:
-  /// Constructs a Lane
-  /// @param id Id of the lane.
-  /// @param left Left polyline describing the left boundary of the lane.
-  /// @param right Right polyline describing the right boundary of the lane.
-  Lane(const LaneId& id, const maliput_sparse::geometry::LineString3d& left,
-       const maliput_sparse::geometry::LineString3d& right)
-      : id_(id), left_(left), right_(right) {}
-
-  /// Constructs a Lane
-  /// @param id Id of the lane.
-  /// @param left Left polyline describing the left boundary of the lane.
-  /// @param right Right polyline describing the right boundary of the lane.
-  /// @param left_lane_id Id of the lane to the left of this lane.
-  /// @param right_lane_id Id of the right to the left of this lane.
-  /// @param successors Ids of the lanes that are successors of this lane.
-  /// @param predecessors Ids of the lanes that are predecessors of this lane.
-  Lane(const LaneId& id, const maliput_sparse::geometry::LineString3d& left,
-       const maliput_sparse::geometry::LineString3d& right, const std::optional<LaneId>& left_lane_id,
-       const std::optional<LaneId>& right_lane_id, const std::vector<LaneId>& successors,
-       const std::vector<LaneId>& predecessors)
-      : id_(id),
-        left_(left),
-        right_(right),
-        left_lane_id_(left_lane_id),
-        right_lane_id_(right_lane_id),
-        successors_(successors),
-        predecessors_(predecessors) {}
-
-  /// Returns the id of the lane.
-  const LaneId& id() const { return id_; }
-  /// Returns the left polyline describing the left boundary of the lane.
-  const maliput_sparse::geometry::LineString3d& left() const { return left_; }
-  /// Returns the right polyline describing the right boundary of the lane.
-  const maliput_sparse::geometry::LineString3d& right() const { return right_; }
-
-  /// Set the id of the lane to the left of this lane.
-  /// @param left_lane_id Left LaneId.
-  void set_left_lane_id(const std::optional<LaneId>& left_lane_id) { left_lane_id_ = left_lane_id; }
-  /// Set the id of the lane to the right of this lane.
-  /// @param right_lane_id Right LaneId.
-  void set_right_lane_id(const std::optional<LaneId>& right_lane_id) { right_lane_id_ = right_lane_id; }
-  /// @returns The id of the lane to the left of this lane.
-  const std::optional<LaneId>& get_left_lane_id() const { return left_lane_id_; }
-  /// @returns The id of the lane to the right of this lane.
-  const std::optional<LaneId>& get_right_lane_id() const { return right_lane_id_; }
-
-  /// Set the ids of the lanes that succeed this lane.
-  /// @param successors Successors.
-  void set_successors(const std::vector<LaneId>& successors) { successors_ = successors; }
-  /// Set the ids of the lanes that precede this lane.
-  /// @param predecessors Predecessors.
-  void set_predecessors(const std::vector<LaneId>& predecessors) { predecessors_ = predecessors; }
-  /// @returns The ids of the lanes that succeed this lane.
-  const std::vector<LaneId>& get_successors() const { return successors_; }
-  /// @returns The ids of the lanes that precede this lane.
-  const std::vector<LaneId>& get_predecessors() const { return predecessors_; }
-
+struct Lane {
   /// Equality operator.
-  /// @param other Other Lane.
+  /// @param other The other object to compare against.
   bool operator==(const Lane& other) const {
-    return id_ == other.id_ && left_ == other.left_ && right_ == other.right_ && left_lane_id_ == other.left_lane_id_ &&
-           right_lane_id_ == other.right_lane_id_ && successors_ == other.successors_ &&
-           predecessors_ == other.predecessors_;
+    return id == other.id && left == other.left && right == other.right && left_lane_id == other.left_lane_id &&
+           right_lane_id == other.right_lane_id && successors == other.successors && predecessors == other.predecessors;
   }
 
- private:
-  const LaneId id_;
-  const maliput_sparse::geometry::LineString3d left_;
-  const maliput_sparse::geometry::LineString3d right_;
-  std::optional<LaneId> left_lane_id_;
-  std::optional<LaneId> right_lane_id_;
-  std::vector<LaneId> successors_;
-  std::vector<LaneId> predecessors_;
+  /// Id of the lane.
+  LaneId id{};
+  /// The lane's left boundary.
+  maliput_sparse::geometry::LineString3d left;
+  /// The lane's right boundary.
+  maliput_sparse::geometry::LineString3d right;
+  /// The id of the lane to the left of this lane.
+  std::optional<LaneId> left_lane_id;
+  /// The id of the lane to the right of this lane.
+  std::optional<LaneId> right_lane_id;
+  /// The ids of the lanes that follow this lane.
+  std::vector<LaneId> successors;
+  /// The ids of the lanes that precede this lane.
+  std::vector<LaneId> predecessors;
 };
 
 }  // namespace osm

--- a/src/maliput_osm/osm/segment.h
+++ b/src/maliput_osm/osm/segment.h
@@ -45,11 +45,26 @@ namespace osm {
 
 using SegmentId = maliput::api::TypeSpecificIdentifier<class Segment>;
 
+/// Abstraction for a road segment obtained from a osm map.
+/// A segment is a collection of lanes added with a strict order, from right to left,
+/// similarly to maliput::api::Segment abstraction.
+///
+/// A lanelet2-osm based map is composed by lanelets that could have adjacent lanes. The collection
+/// of adjacent lanes are expected to be grouped in the Segment abstraction.
 class Segment {
  public:
+  /// @param id Id of the lane.
+  /// @param lanes Lanes in the segment added from left to right.
+  /// @throws maliput::common::assertion_error When @p lanes is empty.
   Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes) : id_(id), lanes_(lanes) {
     MALIPUT_THROW_UNLESS(!lanes_.empty());
   }
+
+  /// @param id Id of the lane.
+  /// @param lanes Lanes in the segment added from right to left.
+  /// @param successors Ids of the lanes that are successors of this lane.
+  /// @param predecessors Ids of the lanes that are predecessors of this lane.
+  /// @throws maliput::common::assertion_error When @p lanes is empty.
   Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes, const std::vector<SegmentId>& successors,
           const std::vector<SegmentId>& predecessors)
       : id_(id), lanes_(lanes), successors_(successors), predecessors_(predecessors) {

--- a/src/maliput_osm/osm/segment.h
+++ b/src/maliput_osm/osm/segment.h
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <map>
 #include <string>
 #include <vector>
 
@@ -40,8 +39,6 @@
 namespace maliput_osm {
 namespace osm {
 
-using SegmentId = std::string;
-
 /// Abstraction for a road segment obtained from a osm map.
 /// A segment is a collection of lanes added with a strict order, from right to left,
 /// similarly to maliput::api::Segment abstraction.
@@ -49,22 +46,16 @@ using SegmentId = std::string;
 /// A lanelet2-osm based map is composed by lanelets that could have adjacent lanes. The collection
 /// of adjacent lanes are expected to be grouped in the Segment abstraction.
 struct Segment {
- public:
+  using Id = std::string;
+
   /// Equality operator.
   /// @param other The other object to compare against.
-  bool operator==(const Segment& other) const {
-    return id == other.id && lanes == other.lanes && successors == other.successors &&
-           predecessors == other.predecessors;
-  }
+  bool operator==(const Segment& other) const { return id == other.id && lanes == other.lanes; }
 
   /// Id of the segment.
-  SegmentId id;
+  Id id;
   /// Collection of lanes that compose the segment.
-  std::map<LaneId, Lane> lanes;
-  /// The ids of the segments that follow this segment.
-  std::vector<SegmentId> successors;
-  /// The ids of the segments that precede this segment.
-  std::vector<SegmentId> predecessors;
+  std::vector<Lane> lanes;
 };
 
 }  // namespace osm

--- a/src/maliput_osm/osm/segment.h
+++ b/src/maliput_osm/osm/segment.h
@@ -1,0 +1,90 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <maliput/api/type_specific_identifier.h>
+#include <maliput/common/assertion_error.h>
+#include <maliput/common/maliput_copyable.h>
+#include <maliput_sparse/geometry/line_string.h>
+
+#include "maliput_osm/osm/lane.h"
+
+namespace maliput_osm {
+namespace osm {
+
+using SegmentId = maliput::api::TypeSpecificIdentifier<class Segment>;
+
+class Segment {
+ public:
+  Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes) : id_(id), lanes_(lanes) {
+    MALIPUT_THROW_UNLESS(!lanes_.empty());
+  }
+  Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes, const std::vector<SegmentId>& successors,
+          const std::vector<SegmentId>& predecessors)
+      : id_(id), lanes_(lanes), successors_(successors), predecessors_(predecessors) {
+    MALIPUT_THROW_UNLESS(!lanes_.empty());
+  }
+
+  /// Returns the id of the segment.
+  const SegmentId& id() const { return id_; }
+  /// Returns the lanes of the segment.
+  const std::map<LaneId, Lane>& lanes() const { return lanes_; }
+
+  /// Set the ids of the lanes that succeed this lane.
+  /// @param successors Successors.
+  void set_successors(const std::vector<SegmentId>& successors) { successors_ = successors; }
+  /// Set the ids of the lanes that precede this lane.
+  /// @param predecessors Predecessors.
+  void set_predecessors(const std::vector<SegmentId>& predecessors) { predecessors_ = predecessors; }
+  /// @returns The ids of the lanes that succeed this lane.
+  const std::vector<SegmentId>& get_successors() const { return successors_; }
+  /// @returns The ids of the lanes that precede this lane.
+  const std::vector<SegmentId>& get_predecessors() const { return predecessors_; }
+
+  /// Equality operator.
+  /// @param other The other object to compare against.
+  bool operator==(const Segment& other) const {
+    return id_ == other.id_ && lanes_ == other.lanes_ && successors_ == other.successors_ &&
+           predecessors_ == other.predecessors_;
+  }
+
+ private:
+  const SegmentId id_;
+  const std::map<LaneId, Lane> lanes_;
+  std::vector<SegmentId> successors_;
+  std::vector<SegmentId> predecessors_;
+};
+
+}  // namespace osm
+}  // namespace maliput_osm

--- a/src/maliput_osm/osm/segment.h
+++ b/src/maliput_osm/osm/segment.h
@@ -30,12 +30,9 @@
 #pragma once
 
 #include <map>
-#include <memory>
 #include <string>
+#include <vector>
 
-#include <maliput/api/type_specific_identifier.h>
-#include <maliput/common/assertion_error.h>
-#include <maliput/common/maliput_copyable.h>
 #include <maliput_sparse/geometry/line_string.h>
 
 #include "maliput_osm/osm/lane.h"
@@ -43,7 +40,7 @@
 namespace maliput_osm {
 namespace osm {
 
-using SegmentId = maliput::api::TypeSpecificIdentifier<class Segment>;
+using SegmentId = std::string;
 
 /// Abstraction for a road segment obtained from a osm map.
 /// A segment is a collection of lanes added with a strict order, from right to left,
@@ -51,54 +48,23 @@ using SegmentId = maliput::api::TypeSpecificIdentifier<class Segment>;
 ///
 /// A lanelet2-osm based map is composed by lanelets that could have adjacent lanes. The collection
 /// of adjacent lanes are expected to be grouped in the Segment abstraction.
-class Segment {
+struct Segment {
  public:
-  /// @param id Id of the lane.
-  /// @param lanes Lanes in the segment added from left to right.
-  /// @throws maliput::common::assertion_error When @p lanes is empty.
-  Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes) : id_(id), lanes_(lanes) {
-    MALIPUT_THROW_UNLESS(!lanes_.empty());
-  }
-
-  /// @param id Id of the lane.
-  /// @param lanes Lanes in the segment added from right to left.
-  /// @param successors Ids of the lanes that are successors of this lane.
-  /// @param predecessors Ids of the lanes that are predecessors of this lane.
-  /// @throws maliput::common::assertion_error When @p lanes is empty.
-  Segment(const SegmentId& id, const std::map<LaneId, Lane>& lanes, const std::vector<SegmentId>& successors,
-          const std::vector<SegmentId>& predecessors)
-      : id_(id), lanes_(lanes), successors_(successors), predecessors_(predecessors) {
-    MALIPUT_THROW_UNLESS(!lanes_.empty());
-  }
-
-  /// Returns the id of the segment.
-  const SegmentId& id() const { return id_; }
-  /// Returns the lanes of the segment.
-  const std::map<LaneId, Lane>& lanes() const { return lanes_; }
-
-  /// Set the ids of the lanes that succeed this lane.
-  /// @param successors Successors.
-  void set_successors(const std::vector<SegmentId>& successors) { successors_ = successors; }
-  /// Set the ids of the lanes that precede this lane.
-  /// @param predecessors Predecessors.
-  void set_predecessors(const std::vector<SegmentId>& predecessors) { predecessors_ = predecessors; }
-  /// @returns The ids of the lanes that succeed this lane.
-  const std::vector<SegmentId>& get_successors() const { return successors_; }
-  /// @returns The ids of the lanes that precede this lane.
-  const std::vector<SegmentId>& get_predecessors() const { return predecessors_; }
-
   /// Equality operator.
   /// @param other The other object to compare against.
   bool operator==(const Segment& other) const {
-    return id_ == other.id_ && lanes_ == other.lanes_ && successors_ == other.successors_ &&
-           predecessors_ == other.predecessors_;
+    return id == other.id && lanes == other.lanes && successors == other.successors &&
+           predecessors == other.predecessors;
   }
 
- private:
-  const SegmentId id_;
-  const std::map<LaneId, Lane> lanes_;
-  std::vector<SegmentId> successors_;
-  std::vector<SegmentId> predecessors_;
+  /// Id of the segment.
+  SegmentId id;
+  /// Collection of lanes that compose the segment.
+  std::map<LaneId, Lane> lanes;
+  /// The ids of the segments that follow this segment.
+  std::vector<SegmentId> successors;
+  /// The ids of the segments that precede this segment.
+  std::vector<SegmentId> predecessors;
 };
 
 }  // namespace osm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,9 @@ if (TARGET ${target})
 
       target_include_directories(${target}
         PRIVATE
-          ${PROJECT_SOURCE_DIR}/include
           ${CMAKE_CURRENT_SOURCE_DIR}
+          ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src
           ${PROJECT_SOURCE_DIR}/test
       )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,21 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_gmock REQUIRED)
+
+macro(add_dependencies_to_test target)
+if (TARGET ${target})
+
+      target_include_directories(${target}
+        PRIVATE
+          ${PROJECT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}
+          ${PROJECT_SOURCE_DIR}/test
+      )
+
+      target_link_libraries(${target}
+          maliput_osm::osm
+      )
+
+    endif()
+endmacro()
+
+add_subdirectory(osm)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,9 @@ if (TARGET ${target})
       )
 
       target_link_libraries(${target}
-          maliput_osm::osm
+        maliput::api
+        maliput::common
+        maliput_sparse::geometry
       )
 
     endif()

--- a/test/dummy_file.cpp
+++ b/test/dummy_file.cpp
@@ -1,1 +1,0 @@
-// To avoid ament_clang_format to fail.

--- a/test/osm/CMakeLists.txt
+++ b/test/osm/CMakeLists.txt
@@ -1,0 +1,4 @@
+ament_add_gtest(lane_test lane_test.cc)
+ament_add_gtest(segment_test segment_test.cc)
+add_dependencies_to_test(lane_test)
+add_dependencies_to_test(segment_test)

--- a/test/osm/CMakeLists.txt
+++ b/test/osm/CMakeLists.txt
@@ -1,4 +1,5 @@
 ament_add_gtest(lane_test lane_test.cc)
 ament_add_gtest(segment_test segment_test.cc)
+
 add_dependencies_to_test(lane_test)
 add_dependencies_to_test(segment_test)

--- a/test/osm/lane_test.cc
+++ b/test/osm/lane_test.cc
@@ -31,7 +31,7 @@
 
 #include <optional>
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 #include <gtest/gtest.h>
 #include <maliput_sparse/geometry/line_string.h>
@@ -45,17 +45,17 @@ using maliput_sparse::geometry::LineString3d;
 
 class LaneTest : public ::testing::Test {
  protected:
-  const LaneId id{"lane_id"};
+  const Lane::Id id{"lane_id"};
   const LineString3d left{{1., 1., 1.}, {10., 1., 1.}};
   const LineString3d right{{1., -1., 1.}, {10., -1., 1.}};
-  const std::optional<LaneId> left_lane_id{"left_lane_id"};
-  const std::optional<LaneId> right_lane_id{"right_lane_id"};
-  const std::vector<LaneId> successors{LaneId{"successor_1"}, LaneId{"successor_2"}};
-  const std::vector<LaneId> predecessors{LaneId{"predecessor_1"}, LaneId{"predecessor_2"}};
+  const std::optional<Lane::Id> left_lane_id{"left_lane_id"};
+  const std::optional<Lane::Id> right_lane_id{"right_lane_id"};
+  const std::unordered_set<Lane::Id> successors{Lane::Id{"successor_1"}, Lane::Id{"successor_2"}};
+  const std::unordered_set<Lane::Id> predecessors{Lane::Id{"predecessor_1"}, Lane::Id{"predecessor_2"}};
+  const Lane dut{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
 };
 
-TEST_F(LaneTest, Test) {
-  const Lane dut{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+TEST_F(LaneTest, Members) {
   EXPECT_EQ(id, dut.id);
   EXPECT_EQ(left, dut.left);
   EXPECT_EQ(right, dut.right);
@@ -63,6 +63,9 @@ TEST_F(LaneTest, Test) {
   EXPECT_EQ(right_lane_id, dut.right_lane_id);
   EXPECT_EQ(successors, dut.successors);
   EXPECT_EQ(predecessors, dut.predecessors);
+}
+
+TEST_F(LaneTest, EqualityOperator) {
   const Lane dut2 = dut;
   EXPECT_EQ(dut, dut2);
 }

--- a/test/osm/lane_test.cc
+++ b/test/osm/lane_test.cc
@@ -55,34 +55,16 @@ class LaneTest : public ::testing::Test {
 };
 
 TEST_F(LaneTest, Test) {
-  EXPECT_NO_THROW(Lane(id, left, right));
-  EXPECT_NO_THROW(Lane(id, left, right, left_lane_id, right_lane_id, successors, predecessors));
-
-  Lane lane{id, left, right};
-  EXPECT_EQ(id, lane.id());
-  EXPECT_EQ(left, lane.left());
-  EXPECT_EQ(right, lane.right());
-  EXPECT_EQ(std::nullopt, lane.get_left_lane_id());
-  EXPECT_EQ(std::nullopt, lane.get_right_lane_id());
-
-  const Lane lane_2{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
-  EXPECT_EQ(lane_2.id(), lane.id());
-  EXPECT_EQ(lane_2.left(), lane.left());
-  EXPECT_EQ(lane_2.right(), lane.right());
-  EXPECT_EQ(left_lane_id, lane_2.get_left_lane_id());
-  EXPECT_EQ(right_lane_id, lane_2.get_right_lane_id());
-  EXPECT_EQ(successors, lane_2.get_successors());
-  EXPECT_EQ(predecessors, lane_2.get_predecessors());
-
-  lane.set_left_lane_id(left_lane_id);
-  lane.set_right_lane_id(right_lane_id);
-  EXPECT_EQ(left_lane_id, lane.get_left_lane_id());
-  EXPECT_EQ(right_lane_id, lane.get_right_lane_id());
-  lane.set_successors(successors);
-  lane.set_predecessors(predecessors);
-  EXPECT_EQ(successors, lane.get_successors());
-  EXPECT_EQ(predecessors, lane.get_predecessors());
-  EXPECT_EQ(lane_2, lane);
+  const Lane dut{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+  EXPECT_EQ(id, dut.id);
+  EXPECT_EQ(left, dut.left);
+  EXPECT_EQ(right, dut.right);
+  EXPECT_EQ(left_lane_id, dut.left_lane_id);
+  EXPECT_EQ(right_lane_id, dut.right_lane_id);
+  EXPECT_EQ(successors, dut.successors);
+  EXPECT_EQ(predecessors, dut.predecessors);
+  const Lane dut2 = dut;
+  EXPECT_EQ(dut, dut2);
 }
 
 }  // namespace

--- a/test/osm/lane_test.cc
+++ b/test/osm/lane_test.cc
@@ -1,0 +1,91 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_osm/osm/lane.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <maliput_sparse/geometry/line_string.h>
+
+namespace maliput_osm {
+namespace osm {
+namespace test {
+namespace {
+
+using maliput_sparse::geometry::LineString3d;
+
+class LaneTest : public ::testing::Test {
+ protected:
+  const LaneId id{"lane_id"};
+  const LineString3d left{{1., 1., 1.}, {10., 1., 1.}};
+  const LineString3d right{{1., -1., 1.}, {10., -1., 1.}};
+  const std::optional<LaneId> left_lane_id{"left_lane_id"};
+  const std::optional<LaneId> right_lane_id{"right_lane_id"};
+  const std::vector<LaneId> successors{LaneId{"successor_1"}, LaneId{"successor_2"}};
+  const std::vector<LaneId> predecessors{LaneId{"predecessor_1"}, LaneId{"predecessor_2"}};
+};
+
+TEST_F(LaneTest, Test) {
+  EXPECT_NO_THROW(Lane(id, left, right));
+  EXPECT_NO_THROW(Lane(id, left, right, left_lane_id, right_lane_id, successors, predecessors));
+
+  Lane lane{id, left, right};
+  EXPECT_EQ(id, lane.id());
+  EXPECT_EQ(left, lane.left());
+  EXPECT_EQ(right, lane.right());
+  EXPECT_EQ(std::nullopt, lane.get_left_lane_id());
+  EXPECT_EQ(std::nullopt, lane.get_right_lane_id());
+
+  const Lane lane_2{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+  EXPECT_EQ(lane_2.id(), lane.id());
+  EXPECT_EQ(lane_2.left(), lane.left());
+  EXPECT_EQ(lane_2.right(), lane.right());
+  EXPECT_EQ(left_lane_id, lane_2.get_left_lane_id());
+  EXPECT_EQ(right_lane_id, lane_2.get_right_lane_id());
+  EXPECT_EQ(successors, lane_2.get_successors());
+  EXPECT_EQ(predecessors, lane_2.get_predecessors());
+
+  lane.set_left_lane_id(left_lane_id);
+  lane.set_right_lane_id(right_lane_id);
+  EXPECT_EQ(left_lane_id, lane.get_left_lane_id());
+  EXPECT_EQ(right_lane_id, lane.get_right_lane_id());
+  lane.set_successors(successors);
+  lane.set_predecessors(predecessors);
+  EXPECT_EQ(successors, lane.get_successors());
+  EXPECT_EQ(predecessors, lane.get_predecessors());
+  EXPECT_EQ(lane_2, lane);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace osm
+}  // namespace maliput_osm

--- a/test/osm/segment_test.cc
+++ b/test/osm/segment_test.cc
@@ -47,29 +47,25 @@ using maliput_sparse::geometry::LineString3d;
 
 class SegmentTest : public ::testing::Test {
  protected:
-  static Lane CreateLane(const LaneId& id) {
+  static Lane CreateLane(const Lane::Id& id) {
     static const LineString3d left{{1., 1., 1.}, {10., 1., 1.}};
     static const LineString3d right{{1., -1., 1.}, {10., -1., 1.}};
-    static const std::optional<LaneId> left_lane_id{"left_lane_id"};
-    static const std::optional<LaneId> right_lane_id{"right_lane_id"};
-    static const std::vector<LaneId> successors{LaneId{"successor_1"}, LaneId{"successor_2"}};
-    static const std::vector<LaneId> predecessors{LaneId{"predecessor_1"}, LaneId{"predecessor_2"}};
-    return {id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+    static const std::optional<Lane::Id> left_lane_id{"left_lane_id"};
+    static const std::optional<Lane::Id> right_lane_id{"right_lane_id"};
+    return {id, left, right, left_lane_id, right_lane_id};
   }
 
-  const SegmentId id_{"segment_id"};
-  const std::map<LaneId, Lane> lanes_{{LaneId{"lane_1"}, CreateLane(LaneId{"lane_1"})},
-                                      {LaneId{"lane_1"}, CreateLane(LaneId{"lane_2"})}};
-  const std::vector<SegmentId> successors_{SegmentId{"successor_1"}, SegmentId{"successor_2"}};
-  const std::vector<SegmentId> predecessors_{SegmentId{"predecessor_1"}, SegmentId{"predecessor_2"}};
+  const Segment::Id id_{"segment_id"};
+  const std::vector<Lane> lanes_{{CreateLane(Lane::Id{"lane_1"})}, {CreateLane(Lane::Id{"lane_2"})}};
+  const Segment dut{id_, lanes_};
 };
 
-TEST_F(SegmentTest, Test) {
-  const Segment dut{id_, lanes_, successors_, predecessors_};
+TEST_F(SegmentTest, Members) {
   EXPECT_EQ(id_, dut.id);
   EXPECT_EQ(lanes_, dut.lanes);
-  EXPECT_EQ(predecessors_, dut.predecessors);
-  EXPECT_EQ(successors_, dut.successors);
+}
+
+TEST_F(SegmentTest, EqualityOperator) {
   const Segment dut2 = dut;
   EXPECT_EQ(dut, dut2);
 }

--- a/test/osm/segment_test.cc
+++ b/test/osm/segment_test.cc
@@ -1,0 +1,93 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_osm/osm/segment.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <maliput_sparse/geometry/line_string.h>
+
+#include "maliput_osm/osm/lane.h"
+
+namespace maliput_osm {
+namespace osm {
+namespace test {
+namespace {
+
+using maliput_sparse::geometry::LineString3d;
+
+class SegmentTest : public ::testing::Test {
+ protected:
+  static Lane CreateLane(const LaneId& id) {
+    static const LineString3d left{{1., 1., 1.}, {10., 1., 1.}};
+    static const LineString3d right{{1., -1., 1.}, {10., -1., 1.}};
+    static const std::optional<LaneId> left_lane_id{"left_lane_id"};
+    static const std::optional<LaneId> right_lane_id{"right_lane_id"};
+    static const std::vector<LaneId> successors{LaneId{"successor_1"}, LaneId{"successor_2"}};
+    static const std::vector<LaneId> predecessors{LaneId{"predecessor_1"}, LaneId{"predecessor_2"}};
+    return {id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+  }
+
+  const SegmentId id_{"segment_id"};
+  const std::map<LaneId, Lane> lanes_{{LaneId{"lane_1"}, CreateLane(LaneId{"lane_1"})},
+                                      {LaneId{"lane_1"}, CreateLane(LaneId{"lane_2"})}};
+  const std::vector<SegmentId> successors_{SegmentId{"successor_1"}, SegmentId{"successor_2"}};
+  const std::vector<SegmentId> predecessors_{SegmentId{"predecessor_1"}, SegmentId{"predecessor_2"}};
+};
+
+TEST_F(SegmentTest, Test) {
+  EXPECT_THROW(Segment(id_, {}), maliput::common::assertion_error);
+  EXPECT_NO_THROW(Segment(id_, lanes_));
+  EXPECT_NO_THROW(Segment(id_, lanes_, successors_, predecessors_));
+
+  Segment segment{id_, lanes_};
+  EXPECT_EQ(id_, segment.id());
+  EXPECT_EQ(lanes_, segment.lanes());
+  EXPECT_TRUE(segment.get_successors().empty());
+  EXPECT_TRUE(segment.get_predecessors().empty());
+
+  const Segment segment_2{id_, lanes_, successors_, predecessors_};
+  EXPECT_EQ(segment.id(), segment_2.id());
+  EXPECT_EQ(segment.lanes(), segment_2.lanes());
+  EXPECT_EQ(successors_, segment_2.get_successors());
+  EXPECT_EQ(predecessors_, segment_2.get_predecessors());
+  segment.set_successors(successors_);
+  segment.set_predecessors(predecessors_);
+  EXPECT_EQ(successors_, segment.get_successors());
+  EXPECT_EQ(predecessors_, segment.get_predecessors());
+  EXPECT_EQ(segment_2, segment);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace osm
+}  // namespace maliput_osm

--- a/test/osm/segment_test.cc
+++ b/test/osm/segment_test.cc
@@ -65,26 +65,13 @@ class SegmentTest : public ::testing::Test {
 };
 
 TEST_F(SegmentTest, Test) {
-  EXPECT_THROW(Segment(id_, {}), maliput::common::assertion_error);
-  EXPECT_NO_THROW(Segment(id_, lanes_));
-  EXPECT_NO_THROW(Segment(id_, lanes_, successors_, predecessors_));
-
-  Segment segment{id_, lanes_};
-  EXPECT_EQ(id_, segment.id());
-  EXPECT_EQ(lanes_, segment.lanes());
-  EXPECT_TRUE(segment.get_successors().empty());
-  EXPECT_TRUE(segment.get_predecessors().empty());
-
-  const Segment segment_2{id_, lanes_, successors_, predecessors_};
-  EXPECT_EQ(segment.id(), segment_2.id());
-  EXPECT_EQ(segment.lanes(), segment_2.lanes());
-  EXPECT_EQ(successors_, segment_2.get_successors());
-  EXPECT_EQ(predecessors_, segment_2.get_predecessors());
-  segment.set_successors(successors_);
-  segment.set_predecessors(predecessors_);
-  EXPECT_EQ(successors_, segment.get_successors());
-  EXPECT_EQ(predecessors_, segment.get_predecessors());
-  EXPECT_EQ(segment_2, segment);
+  const Segment dut{id_, lanes_, successors_, predecessors_};
+  EXPECT_EQ(id_, dut.id);
+  EXPECT_EQ(lanes_, dut.lanes);
+  EXPECT_EQ(predecessors_, dut.predecessors);
+  EXPECT_EQ(successors_, dut.successors);
+  const Segment dut2 = dut;
+  EXPECT_EQ(dut, dut2);
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

Related to #1 

## Summary

Lane and Segment classes/strucutres to be filled by the parser(During OSMManager's constructor time) and to be provided by the OSMManager. For reference the OSMManager
```cpp
namespace maliput_osm {
namespace osm {

class OSMManager {
 public:
  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(OSMManager)

  OSMManager(const std::string& osm_file_path);

  ~OSMManager();

  const std::unordered_map<SegmentId, Segment>& GetOSMSegments() const;

 private:
  class Impl;
  std::unique_ptr<Impl> impl_;
};

}  // namespace osm
}  // namespace maliput_osm
```

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
