### PR TITLE
Matches with branchpoint builder implementation.

### DIFF
--- a/src/maliput_osm/builder/road_geometry_builder.cc
+++ b/src/maliput_osm/builder/road_geometry_builder.cc
@@ -69,7 +69,7 @@ std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryBuilder::operator(
     segment_builder.EndSegment().EndJunction();
   }
   // TODO(#18): Build branchpoints.
-  return rg_builder.Build();
+  return rg_builder.StartBranchPoints().EndBranchPoints().Build();
 }
 
 }  // namespace builder


### PR DESCRIPTION
# 🦟 Bug fix

Matches with https://github.com/maliput/maliput_sparse/pull/24

## Summary
It was failing when creating the road geometry because of the constraint of having a branch point at the ends of each lane.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
