### PR TITLE
Parses adjacent lane information from osm maps.

### DIFF
--- a/src/maliput_osm/osm/conversions.cc
+++ b/src/maliput_osm/osm/conversions.cc
@@ -30,6 +30,8 @@
 #include "maliput_osm/osm/conversions.h"
 
 #include <algorithm>
+#include <optional>
+#include <string>
 
 using maliput_sparse::geometry::LineString3d;
 
@@ -43,8 +45,32 @@ LineString3d ToMaliput(const lanelet::ConstLineString3d& line_string) {
   return LineString3d{points};
 }
 
-Lane ToMaliput(const lanelet::Lanelet& lanelet) {
-  return {std::to_string(lanelet.id()), ToMaliput(lanelet.leftBound()), ToMaliput(lanelet.rightBound())};
+Lane ToMaliput(const lanelet::Lanelet& lanelet, const lanelet::LaneletLayer& map_layer) {
+  // Get Id.
+  const std::string id = std::to_string(lanelet.id());
+  // Get left boundary.
+  const LineString3d left_bound = ToMaliput(lanelet.leftBound());
+  // Get right boundary.
+  const LineString3d right_bound = ToMaliput(lanelet.rightBound());
+
+  // Obtains the lanelets that uses same @p bound linestring.
+  auto find_usage_of_lane_bounds = [&lanelet, &map_layer](const lanelet::ConstLineString3d& bound) {
+    const auto lanelets = map_layer.findUsages(bound);
+    MALIPUT_THROW_UNLESS(lanelets.size() >= 1);
+    MALIPUT_THROW_UNLESS(lanelets.size() <= 2);
+    const auto lanelet_it = std::find_if(lanelets.begin(), lanelets.end(), [&lanelet](const auto& lanelet_usage) {
+      return lanelet_usage.id() != lanelet.id();
+    });
+    return lanelet_it != lanelets.end() ? std::make_optional<std::string>(std::to_string(lanelet_it->id()))
+                                        : std::nullopt;
+  };
+  // Get left lane id.
+  const std::optional<std::string> left_lane_id = find_usage_of_lane_bounds(lanelet.leftBound());
+  // Get left right id.
+  const std::optional<std::string> right_lane_id = find_usage_of_lane_bounds(lanelet.rightBound());
+
+  // TODO(#26): Find the successor and predecessor lanelets.
+  return {id, left_bound, right_bound, left_lane_id, right_lane_id, {} /* successors */, {} /* predecessors */};
 }
 
 }  // namespace osm

--- a/src/maliput_osm/osm/conversions.h
+++ b/src/maliput_osm/osm/conversions.h
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <maliput_sparse/geometry/line_string.h>
 
@@ -45,11 +46,11 @@ maliput_sparse::geometry::LineString3d ToMaliput(const lanelet::ConstLineString3
 /// Converts a lanelet::Lanelet to a maliput_osm::osm::Lane.
 ///
 /// maliput_osm::osm::Lane is an struct with several fields.
-/// This method only populates the id, left and right fields.
 ///
 /// @param lanelet The lanelet::Lanelet to convert.
+/// @param map_layer lanelet::LaneletLayer for finding adjacent lanelets.
 /// @returns The converted maliput_osm::osm::Lane.
-Lane ToMaliput(const lanelet::Lanelet& lanelet);
+Lane ToMaliput(const lanelet::Lanelet& lanelet, const lanelet::LaneletLayer& map_layer);
 
 }  // namespace osm
 }  // namespace maliput_osm

--- a/src/maliput_osm/osm/osm_manager.cc
+++ b/src/maliput_osm/osm/osm_manager.cc
@@ -47,7 +47,7 @@ OSMManager::OSMManager(const std::string& osm_file_path, const ParserConfig& con
                        osm_file_path);
 
   for (const auto& lanelet : map->laneletLayer) {
-    const Lane lane{ToMaliput(lanelet)};
+    const Lane lane = ToMaliput(lanelet, map->laneletLayer);
     const Segment::Id segment_id{"segment_" + std::to_string(lanelet.id())};
     segments_.emplace(segment_id, Segment{segment_id, {lane}});
   }


### PR DESCRIPTION
# 🎉 New feature

Related to #16 

## Summary
In order to support multiple lanes per segment we need first to identify the lanelets that we could consider that could fit into maliput segment.

For doing so, adjacent lanelets are expected to share boundaries (left or right linestrings). So we can benefit about this in order to create segments.
This PR uses lanelet2's api in order to identify adjacent lanes.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
