### PR TITLE
Use SPDX identifier in license tag.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>0.1.0</version>
   <description>Maliput backend for loading lanelet2-based osm maps.</description>
   <maintainer email="daniel.stonier@tri.global">Daniel Stonier</maintainer>
-  <license file="LICENSE">BSD Clause 3</license>
+  <license file="LICENSE">BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <doc_depend>ament_cmake_doxygen</doc_depend>


### PR DESCRIPTION
This updates the license tag to use the SPDX identifier for the 3 clause BSD license: https://opensource.org/licenses/BSD-3-Clause.