### PR TITLE
Matches with changes in maliput_sparse.

### DIFF
--- a/src/test_utilities/builder_configuration_for_osm.cc
+++ b/src/test_utilities/builder_configuration_for_osm.cc
@@ -55,6 +55,30 @@ std::optional<builder::BuilderConfiguration> GetBuilderConfigurationFor(const st
            utilities::FindOSMResource("straight_forward.osm"),
            {0., 0.} /* origin */,
        }},
+      {"arc_lane.osm",
+       builder::BuilderConfiguration{
+           {
+               maliput::api::RoadGeometryId{"arc_lane"},
+               5e-2 /* linear_tolerance */,
+               1e-3 /* angular_tolerance */,
+               1. /* scale_length */,
+               kZeroVector,
+           },
+           utilities::FindOSMResource("arc_lane.osm"),
+           {0., 0.} /* origin */,
+       }},
+      {"arc_lane_dense.osm",
+       builder::BuilderConfiguration{
+           {
+               maliput::api::RoadGeometryId{"arc_lane_dense"},
+               5e-2 /* linear_tolerance */,
+               1e-3 /* angular_tolerance */,
+               1. /* scale_length */,
+               kZeroVector,
+           },
+           utilities::FindOSMResource("arc_lane_dense.osm"),
+           {0., 0.} /* origin */,
+       }},
       {"multi_lanes_road.osm",
        builder::BuilderConfiguration{
            {

--- a/test/builder/road_geometry_builder_test.cc
+++ b/test/builder/road_geometry_builder_test.cc
@@ -91,6 +91,16 @@ std::vector<RoadGeometryBuilderTestParameters> InstantiateBuilderParameters() {
        {
            {JunctionId("0"), {{{SegmentId("0")}, {LaneId("1006"), LaneId("1010")}}}},
        }},
+      {"arc_lane.osm",
+       "arc_lane",
+       {
+           {JunctionId("0"), {{{SegmentId("0")}, {LaneId("1044"), LaneId("1068")}}}},
+       }},
+      {"arc_lane_dense.osm",
+       "arc_lane_dense",
+       {
+           {JunctionId("0"), {{{SegmentId("0")}, {LaneId("2956"), LaneId("3985")}}}},
+       }},
       {"multi_lanes_road.osm",
        "multi_lanes_road",
        {


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>

# 🦟 Bug fix

Fixes https://github.com/maliput/delphyne_demos/issues/57
Depends on  https://github.com/maliput/maliput_sparse/pull/48

## Summary
 - Matches with changes in https://github.com/maliput/maliput_sparse/pull/48
 - Adds arc_lane and arc_lane_dense as test maps in the `road_geometry_builder_test` file.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/9ee75ed6f31a0d7070a6b8af189e33a0/raw/efd5658ceac7ce194f9d9ae11095444289fb658c/maliput_osm.repos
