### PR TITLE
Uses compare methods instead of maliput test utilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: gcc
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -10,6 +12,11 @@ on:
 env:
   PACKAGE_NAME: maliput_osm
   ROS_DISTRO: foxy
+
+# Cancel previously running PR jobs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   compile_and_test:

--- a/src/test_utilities/CMakeLists.txt
+++ b/src/test_utilities/CMakeLists.txt
@@ -23,7 +23,6 @@ target_include_directories(
 
 target_link_libraries(test_utilities
    PRIVATE
-    maliput::test_utilities
     maliput_osm::osm
     maliput_osm::utilities
     maliput_sparse::geometry

--- a/src/test_utilities/osm_types_compare.cc
+++ b/src/test_utilities/osm_types_compare.cc
@@ -29,7 +29,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "test_utilities/osm_types_compare.h"
 
-#include <maliput/test_utilities/maliput_math_compare.h>
 #include <maliput_sparse/test_utilties/maliput_sparse_types_compare.h>
 
 namespace maliput_osm {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,6 @@ if (TARGET ${target})
         maliput::api
         maliput::common
         maliput::plugin
-        maliput::test_utilities
         maliput_osm::builder
         maliput_osm::osm
         maliput_osm::osm_utilities


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/issues/602

## Summary
 - Do not use `maliput::test_utilities`'s compare methods.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
