### PR TITLE
Updates ros-tooling verison to avoid error with dependency.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       image: ubuntu:20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
     - uses: ros-tooling/action-ros-ci@v0.2
       id: action_ros_ci_step
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
     # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: clang 8 install

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -60,7 +60,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
     - name: colcon build
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
     # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: clang 8 install

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -47,7 +47,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --from-paths src
     - name: colcon build up-to
       shell: bash


### PR DESCRIPTION
# 🦟 Bug fix

Pairs with https://github.com/maliput/maliput_infrastructure/pull/317

## Summary

Updates setup-ros to use v0.6 to avoid erros with empy.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
